### PR TITLE
Typo for stateGet

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class MqttSwitchTasmotaAccessory {
 
     const handlers = {
       [config.topics.statusGet]: this.receiveStatus.bind(this),
-      [config.topics.StateGet]:  this.receiveState.bind(this),
+      [config.topics.stateGet]:  this.receiveState.bind(this),
       [config.activityTopic]:    this.receiveActivity.bind(this),
     };
 


### PR DESCRIPTION
When defining the handlers for the various topics, there is a typo that prevents telemetry status updates from actually updating the switch status. This also adds a .gitignore file to eliminate git from trying to track the node_modules directory when this repo is in use on a "live" system.